### PR TITLE
Update metacom protocol

### DIFF
--- a/doc/Metacom-2.md
+++ b/doc/Metacom-2.md
@@ -1,0 +1,64 @@
+# Metacom protocol Version 2
+
+[Metacom](https://github.com/metarhia/metacom) is a top-level application
+protocol for RPC (remote procedure call) and large binary objects transfer.
+Metacom requires frame-based transport, for example
+[websocket](https://tools.ietf.org/html/rfc6455).
+[TCP](https://tools.ietf.org/html/rfc793) and
+[TLS](https://tools.ietf.org/html/rfc8446) can be used as underlying transport
+but additional converting layer (described below) is needed to have frame-based
+transport instead of stream-based one. Metacom can support multiple serialization
+formats like [JSON](https://tools.ietf.org/html/rfc8259) (by default) and
+[MDSF](https://github.com/metarhia/mdsf) (JSON5 implementation),
+[V8 serialization API](https://nodejs.org/api/v8.html#v8_serialization_api),
+[BSON](http://bsonspec.org/), etc. Metacom is a simplification and modernization
+of [JSTP protocol](https://github.com/metarhia/jstp).
+
+## Packet types
+
+There are following packet types: `call`, `callback`, `event`, `stream`, `ping`.
+
+## Calls and callbacks
+
+```js
+// Format:
+{"call":<Number>,"interface.version/method":{<parameters>}}
+{"callback":<Number>,"result":<any>,"error":{"code":<Number>,"message":<String>}}
+
+// Example:
+{"call":110,"auth/signIn":{"login":"marcus","password":"marcus"}}
+{"callback":110,"result":{"token":"2bSpjzG8lTSHaqihGQCgrldypyFAsyme"}}
+```
+
+## Events
+
+```js
+// Format:
+{"event":<Number>,"interface/event":{<parameters>}}
+
+// Example:
+{"event":-25,"chat/message":{"from":"marcus","message":"Hello!"}}
+```
+
+## Streams
+
+```js
+// Stream initialization
+{"stream":<Number>,"name":<String>,"size":<Number>}
+
+// Stream chunk
+{"stream":<Number>}
+// Next frame: <Buffer>
+
+// Stream finalization
+{"stream":<Number>,"status":"end"}
+
+// Stream termination
+{"stream":<Number>,"status":"terminate"}
+```
+
+## Ping packets
+
+Client may periodically generate ping packets `{}` (empty objects, without
+fields and id) to test connection. Server should also answer with empty object
+`{}`.

--- a/doc/Metacom.md
+++ b/doc/Metacom.md
@@ -25,8 +25,7 @@ Call format:
 {
   type: "call",
   id: number,      // we need call id to match result (metacom callback packet)
-  unit: string,    // application subsystem or interface name; may contain version: "chat.5"
-  method: string,  // method name in the scope of unit
+  method: string,  // method name format: unit/name or unit.version/name, example: "chat.5/send"
   args: object,    // we use named arguments to be able marc them optional
   meta: object,    // field for optional passthrough metadata
 }
@@ -45,7 +44,7 @@ Callback format:
 
 Examples:
 ```json
-{"type":"call","id":110,"unit":"auth","method":"signIn","args":{"login":"marcus","password":"marcus"}}
+{"type":"call","id":110,"method":"auth/signIn","args":{"login":"marcus","password":"marcus"}}
 {"callback":110,"result":{"token":"2bSpjzG8lTSHaqihGQCgrldypyFAsyme"}}
 ```
 
@@ -55,8 +54,7 @@ Format:
 ```js
 {
   type: "event", // events have no packet id, unlike call packets and events in metacom version 2
-  unit: string,  // application subsystem
-  name: string,  // event name
+  name: string,  // event name in format: unit/name, example: "chat/message"
   data: object,  // attached data
   meta: object,  // field for optional passthrough metadata
 }
@@ -64,7 +62,7 @@ Format:
 
 Example:
 ```json
-{"type":"event","unit":"chat","name":"message","data":{"from":"marcus","message":"Hello!"}}
+{"type":"event","name":"unit/message","data":{"from":"marcus","message":"Hello!"}}
 ```
 
 ## Streams

--- a/doc/Metacom.md
+++ b/doc/Metacom.md
@@ -24,10 +24,10 @@ Call format:
 ```js
 {
   "type": "call",
-  "id": number,
-  "interface": string,
+  "id": number,         // we need call id to match result (metacom callback packet)
+  "interface": string,  // interface may contain version, for example "chat.5"
   "method": string,
-  "args": object
+  "args": object        // we use named arguments to be able marc them optional
 }
 ```
 
@@ -36,11 +36,8 @@ Callback format:
 {
   "type": "callback",
   "id": number,
-  "result": any,
-  "error": {
-    "code": number,
-    "message": string
-  }
+  "result": any,        // any data (object, array or a single value)
+  "error": { "code": number, "message": string }
 }
 ```
 
@@ -55,7 +52,7 @@ Examples:
 Format:
 ```js
 {
-  "type": "event",
+  "type": "event", // events have no packet id, unlike call packets and events in metacom version 2
   "interface": string,
   "name": string,
   "args": object

--- a/doc/Metacom.md
+++ b/doc/Metacom.md
@@ -23,27 +23,29 @@ There are following packet types: `call`, `callback`, `event`, `stream`, `ping`.
 Call format:
 ```js
 {
-  "type": "call",
-  "id": number,         // we need call id to match result (metacom callback packet)
-  "interface": string,  // interface may contain version, for example "chat.5"
-  "method": string,
-  "args": object        // we use named arguments to be able marc them optional
+  type: "call",
+  id: number,      // we need call id to match result (metacom callback packet)
+  unit: string,    // application subsystem or interface name; may contain version: "chat.5"
+  method: string,  // method name in the scope of unit
+  args: object,    // we use named arguments to be able marc them optional
+  meta: object,    // field for optional passthrough metadata
 }
 ```
 
 Callback format:
 ```js
 {
-  "type": "callback",
-  "id": number,         // 
-  "result": any,        // any data (object, array or a single value)
-  "error": { "code": number, "message": string }
+  type: "callback",
+  id: number,      // call id
+  result: any,     // any data (object, array or a single value)
+  error: { "code": number, "message": string },
+  meta: object,    // field for optional passthrough metadata
 }
 ```
 
 Examples:
 ```json
-{"type":"call","id":110,"interface":"auth","method":"signIn","args":{"login":"marcus","password":"marcus"}}
+{"type":"call","id":110,"unit":"auth","method":"signIn","args":{"login":"marcus","password":"marcus"}}
 {"callback":110,"result":{"token":"2bSpjzG8lTSHaqihGQCgrldypyFAsyme"}}
 ```
 
@@ -52,40 +54,28 @@ Examples:
 Format:
 ```js
 {
-  "type": "event", // events have no packet id, unlike call packets and events in metacom version 2
-  "interface": string,
-  "name": string,
-  "data": object
+  type: "event", // events have no packet id, unlike call packets and events in metacom version 2
+  unit: string,  // application subsystem
+  name: string,  // event name
+  data: object,  // attached data
+  meta: object,  // field for optional passthrough metadata
 }
 ```
 
 Example:
 ```json
-{"type":"event","interface":"chat","name":"message","data":{"from":"marcus","message":"Hello!"}}
+{"type":"event","unit":"chat","name":"message","data":{"from":"marcus","message":"Hello!"}}
 ```
 
 ## Streams
 
-Stream initialization:
-```js
-{ "type": "stream", "id": number, "name": string, "size": number }
-```
+Stream initialization: `{"type":"stream","id":number,"name":string,"size":number}`
 
-Stream chunk:
-```js
-{ "type": "stream", "id": number }
-```
-Next frame: `Buffer`
+Stream chunk: `{"type":"stream","id": number}`; Next frame: `Buffer`.
 
-Stream finalization:
-```js
-{ "type": "stream", "id": number, "status": "end" }
-```
+Stream finalization: `{"type":"stream","id":number,"status":"end"}`
 
-Stream termination:
-```js
-{ "type": "stream", "id": number, "status": "terminate" }
-```
+Stream termination:`{"type":"stream","id":number,"status":"terminate"}`
 
 ## Ping packets
 

--- a/doc/Metacom.md
+++ b/doc/Metacom.md
@@ -22,11 +22,11 @@ There are following packet types: `call`, `callback`, `event`, `stream`, `ping`.
 
 ```js
 // Format:
-{"call":<Number>,"interface.version/method":{<parameters>}}
-{"callback":<Number>,"result":<any>,"error":{"code":<Number>,"message":<String>}}
+{"type":"call","id":<Number>,"interface":<String>,"method":<String>,"args":<Object>}
+{"type":"callback","id":<Number>,"result":<any>,"error":{"code":<Number>,"message":<String>}}
 
 // Example:
-{"call":110,"auth/signIn":{"login":"marcus","password":"marcus"}}
+{"type":"call","id":110,"interface":"auth","method":"signIn","args":{"login":"marcus","password":"marcus"}}
 {"callback":110,"result":{"token":"2bSpjzG8lTSHaqihGQCgrldypyFAsyme"}}
 ```
 
@@ -34,27 +34,27 @@ There are following packet types: `call`, `callback`, `event`, `stream`, `ping`.
 
 ```js
 // Format:
-{"event":<Number>,"interface/event":{<parameters>}}
+{"type":"event","interface":<String>,"name":<String>,"args":<Object>}
 
 // Example:
-{"event":-25,"chat/message":{"from":"marcus","message":"Hello!"}}
+{"type":"event","interface":"chat","name":"message","args":{"from":"marcus","message":"Hello!"}}
 ```
 
 ## Streams
 
 ```js
 // Stream initialization
-{"stream":<Number>,"name":<String>,"size":<Number>}
+{"type":"stream","id":<Number>,"name":<String>,"size":<Number>}
 
 // Stream chunk
-{"stream":<Number>}
+{"type":"stream","id":<Number>}
 // Next frame: <Buffer>
 
 // Stream finalization
-{"stream":<Number>,"status":"end"}
+{"type":"stream","id":<Number>,"status":"end"}
 
 // Stream termination
-{"stream":<Number>,"status":"terminate"}
+{"type":"stream","id":<Number>,"status":"terminate"}
 ```
 
 ## Ping packets

--- a/doc/Metacom.md
+++ b/doc/Metacom.md
@@ -35,7 +35,7 @@ Callback format:
 ```js
 {
   "type": "callback",
-  "id": number,
+  "id": number,         // 
   "result": any,        // any data (object, array or a single value)
   "error": { "code": number, "message": string }
 }
@@ -55,13 +55,13 @@ Format:
   "type": "event", // events have no packet id, unlike call packets and events in metacom version 2
   "interface": string,
   "name": string,
-  "args": object
+  "data": object
 }
 ```
 
 Example:
 ```json
-{"type":"event","interface":"chat","name":"message","args":{"from":"marcus","message":"Hello!"}}
+{"type":"event","interface":"chat","name":"message","data":{"from":"marcus","message":"Hello!"}}
 ```
 
 ## Streams

--- a/doc/Metacom.md
+++ b/doc/Metacom.md
@@ -1,4 +1,4 @@
-# Metacom protocol
+# Metacom protocol Version 3
 
 [Metacom](https://github.com/metarhia/metacom) is a top-level application
 protocol for RPC (remote procedure call) and large binary objects transfer.
@@ -20,41 +20,74 @@ There are following packet types: `call`, `callback`, `event`, `stream`, `ping`.
 
 ## Calls and callbacks
 
+Call format:
 ```js
-// Format:
-{"type":"call","id":<Number>,"interface":<String>,"method":<String>,"args":<Object>}
-{"type":"callback","id":<Number>,"result":<any>,"error":{"code":<Number>,"message":<String>}}
+{
+  "type": "call",
+  "id": number,
+  "interface": string,
+  "method": string,
+  "args": object
+}
+```
 
-// Example:
+Callback format:
+```js
+{
+  "type": "callback",
+  "id": number,
+  "result": any,
+  "error": {
+    "code": number,
+    "message": string
+  }
+}
+```
+
+Examples:
+```json
 {"type":"call","id":110,"interface":"auth","method":"signIn","args":{"login":"marcus","password":"marcus"}}
 {"callback":110,"result":{"token":"2bSpjzG8lTSHaqihGQCgrldypyFAsyme"}}
 ```
 
 ## Events
 
+Format:
 ```js
-// Format:
-{"type":"event","interface":<String>,"name":<String>,"args":<Object>}
+{
+  "type": "event",
+  "interface": string,
+  "name": string,
+  "args": object
+}
+```
 
-// Example:
+Example:
+```json
 {"type":"event","interface":"chat","name":"message","args":{"from":"marcus","message":"Hello!"}}
 ```
 
 ## Streams
 
+Stream initialization:
 ```js
-// Stream initialization
-{"type":"stream","id":<Number>,"name":<String>,"size":<Number>}
+{ "type": "stream", "id": number, "name": string, "size": number }
+```
 
-// Stream chunk
-{"type":"stream","id":<Number>}
-// Next frame: <Buffer>
+Stream chunk:
+```js
+{ "type": "stream", "id": number }
+```
+Next frame: `Buffer`
 
-// Stream finalization
-{"type":"stream","id":<Number>,"status":"end"}
+Stream finalization:
+```js
+{ "type": "stream", "id": number, "status": "end" }
+```
 
-// Stream termination
-{"type":"stream","id":<Number>,"status":"terminate"}
+Stream termination:
+```js
+{ "type": "stream", "id": number, "status": "terminate" }
 ```
 
 ## Ping packets


### PR DESCRIPTION
- Added field `type`
- Field order in JSON may be random
- Now metacom packets can be validated with metaschema
- We do not need id in event packets
- Passthrough field `meta` added for metadata

Pure node.js server prototype: https://github.com/metatech-university/NodeJS-Pure/pull/17
Browser client prototype: https://github.com/metatech-university/NodeJS-Application/pull/7